### PR TITLE
Added $_ENV precedence to getenv()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2263,16 +2263,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.0",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "00bed125812716d09b163f0727ef33bb49bf3448"
+                "reference": "0f0a271bc9b7d02a053d36fcdcb12662e2a8096e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/00bed125812716d09b163f0727ef33bb49bf3448",
-                "reference": "00bed125812716d09b163f0727ef33bb49bf3448",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0f0a271bc9b7d02a053d36fcdcb12662e2a8096e",
+                "reference": "0f0a271bc9b7d02a053d36fcdcb12662e2a8096e",
                 "shasum": ""
             },
             "require": {
@@ -2352,7 +2352,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-30T20:35:19+00:00"
+            "time": "2020-06-07T19:47:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2872,16 +2872,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.0",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "90c2a5103f07feb19069379f3abdcdbacc7753a9"
+                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/90c2a5103f07feb19069379f3abdcdbacc7753a9",
-                "reference": "90c2a5103f07feb19069379f3abdcdbacc7753a9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ac70459db781108db7c6d8981dd31ce0e29e3298",
+                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298",
                 "shasum": ""
             },
             "require": {
@@ -2953,11 +2953,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-06-11T12:16:36+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.1.0",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+
+namespace Env;
+
+/**
+ * Environment Variable Loader.
+ */
+abstract class Loader {
+  /**
+   * Stores environment variables.
+   *
+   * @var array<string,mixed>
+   */
+  protected static $env = [];
+
+  /**
+   * Loads environment variables into a static variable to be used by the class.
+   *
+   * @return void
+   */
+  protected static function loadEnv(): void {
+    if (empty(self::$env)) {
+      self::$env = $_ENV ?: getenv();
+    }
+  }
+
+  /**
+   * Updates environment variables local copy.
+   *
+   * @return void
+   */
+  public static function updateEnv(): void {
+    self::$env = [];
+    self::loadEnv();
+  }
+}

--- a/src/Read.php
+++ b/src/Read.php
@@ -6,35 +6,7 @@ namespace Env;
 /**
  * Environment Variable Reader.
  */
-class Read {
-  /**
-   * Stores environment variables.
-   *
-   * @var array<string,mixed>
-   */
-  private static $env = [];
-
-  /**
-   * Loads environment variables into a static variable to be used by the class.
-   *
-   * @return void
-   */
-  private static function loadEnv(): void {
-    if (empty(self::$env)) {
-      self::$env = getenv();
-    }
-  }
-
-  /**
-   * Updates environment variables local copy.
-   *
-   * @return void
-   */
-  public static function updateEnv(): void {
-    self::$env = [];
-    self::loadEnv();
-  }
-
+class Read extends Loader {
   /**
    * Return an environment variable value as a string.
    *

--- a/src/Required.php
+++ b/src/Required.php
@@ -8,35 +8,7 @@ use RuntimeException;
 /**
  * Environment Variable Reader.
  */
-class Required {
-  /**
-   * Stores environment variables.
-   *
-   * @var array<string,mixed>
-   */
-  private static $env = [];
-
-  /**
-   * Loads environment variables into a static variable to be used by the class.
-   *
-   * @return void
-   */
-  private static function loadEnv(): void {
-    if (empty(self::$env)) {
-      self::$env = getenv();
-    }
-  }
-
-  /**
-   * Updates environment variables local copy.
-   *
-   * @return void
-   */
-  public static function updateEnv(): void {
-    self::$env = [];
-    self::loadEnv();
-  }
-
+class Required extends Loader {
   /**
    * Return an environment variable value as a string or throws an exception if it is not set.
    *

--- a/test/LoaderTest.php
+++ b/test/LoaderTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Test;
+
+use Env\Loader;
+use PHPUnit\Framework\TestCase;
+
+final class LoaderTest extends TestCase {
+  private function getTestDummy(): Loader {
+    return new class extends Loader {
+      public static function forceLoad(): void {
+        self::loadEnv();
+      }
+
+      /**
+       * @return array<string,mixed>
+       */
+      public static function getEnv(): array {
+        return self::$env;
+      }
+    };
+  }
+
+  public function testLoadFromEnvVar(): void {
+    $_ENV = [
+      'a' => 'b',
+      'c' => 1
+    ];
+
+    $testDummy = $this->getTestDummy();
+    $testDummy::forceLoad();
+    $this->assertEquals($_ENV, $testDummy::getEnv());
+  }
+
+  public function testLoadFromGetenv(): void {
+    $_ENV = [];
+    $vars = [
+      'a' => 'b',
+      'c' => 'd'
+    ];
+    foreach ($vars as $key => $value) {
+      putenv(sprintf('%s=%s', $key, $value));
+    }
+
+    $testDummy = $this->getTestDummy();
+    $testDummy::forceLoad();
+    $env = $testDummy::getEnv();
+    $this->assertSame($vars['a'], $env['a']);
+    $this->assertSame($vars['c'], $env['c']);
+  }
+
+  public function testUpdateEnvFromEnvVar(): void {
+    $_ENV = [];
+    $testDummy = $this->getTestDummy();
+    $testDummy::forceLoad();
+    $this->assertEquals(getenv(), $testDummy::getEnv());
+
+    $_ENV = [
+      'd' => 'e'
+    ];
+    $testDummy::updateEnv();
+    $this->assertEquals($_ENV, $testDummy::getEnv());
+  }
+
+  public function testUpdateEnvFromGetenv(): void {
+    $testDummy = $this->getTestDummy();
+    $testDummy::forceLoad();
+    $this->assertEquals(getenv(), $testDummy::getEnv());
+
+    $vars = [
+      'f' => 'g'
+    ];
+    foreach ($vars as $key => $value) {
+      putenv(sprintf('%s=%s', $key, $value));
+    }
+
+    $testDummy::updateEnv();
+    $env = $testDummy::getEnv();
+    $this->assertSame($vars['f'], $env['f']);
+  }
+}

--- a/test/ReadTest.php
+++ b/test/ReadTest.php
@@ -3,27 +3,17 @@ declare(strict_types=1);
 
 namespace Test;
 
+use Env\Loader;
 use Env\Read;
 use PHPUnit\Framework\TestCase;
 
 final class ReadTest extends TestCase {
-  public function testUpdateEnv(): void {
-    $val = Read::asString('testUpdate', 'defaultVal');
-    $this->assertSame('defaultVal', $val);
-
-    putenv('testUpdate=updatedVal');
-    Read::updateEnv();
-
-    $val = Read::asString('testUpdate', 'defaultVal');
-    $this->assertSame('updatedVal', $val);
-  }
-
   public function testReadAsStringDefaultValue(): void {
     $val = Read::asString('testAsString', 'defaultVal');
     $this->assertSame('defaultVal', $val);
   }
 
-  public function testReadAsString(): void {
+  public function testReadAsStringGetenv(): void {
     putenv('testAsString=myVal');
 
     $val = Read::asString('testAsString', 'defaultVal');

--- a/test/ReadTest.php
+++ b/test/ReadTest.php
@@ -13,7 +13,7 @@ final class ReadTest extends TestCase {
     $this->assertSame('defaultVal', $val);
   }
 
-  public function testReadAsStringGetenv(): void {
+  public function testReadAsString(): void {
     putenv('testAsString=myVal');
 
     $val = Read::asString('testAsString', 'defaultVal');

--- a/test/RequiredTest.php
+++ b/test/RequiredTest.php
@@ -8,18 +8,6 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 final class RequiredTest extends TestCase {
-  public function testUpdateEnv(): void {
-    $this->expectException(RuntimeException::class);
-    $this->expectExceptionMessage('"testUpdate" is not set');
-    $val = Required::asString('testUpdate');
-
-    putenv('testUpdate=updatedVal');
-    Required::updateEnv();
-
-    $val = Required::asString('testUpdate');
-    $this->assertSame('updatedVal', $val);
-  }
-
   public function testRequiredAsStringUnsetValue(): void {
     $this->expectException(RuntimeException::class);
     $this->expectExceptionMessage('"testAsString" is not set');


### PR DESCRIPTION
This PR changes the way that the environment variables are loaded.

The library will now try to load the environment variables from `$_ENV`.
If `$_ENV` is empty, it will fallback to loading from `getenv()`, as before.